### PR TITLE
Hedemann soomro/tuning hz parameters

### DIFF
--- a/robotino_navigation/config/nav2_params.yaml
+++ b/robotino_navigation/config/nav2_params.yaml
@@ -221,8 +221,8 @@ controller_server:
 local_costmap:
   local_costmap:
     ros__parameters:
-      update_frequency: 20.0
-      publish_frequency: 20.0
+      update_frequency: 15.0
+      publish_frequency: 15.0
       global_frame: odom
       robot_base_frame: base_link
       use_sim_time: false
@@ -282,9 +282,9 @@ local_costmap:
 global_costmap:
   global_costmap:
     ros__parameters:
-      # footprint_padding: 0.075  # robot footprint padding in mtr.
-      update_frequency: 20.0        # default 1.0
-      publish_frequency: 20.0       # default 1.0
+      #footprint_padding: 0.075  #robot footprint padding in mtr.
+      update_frequency: 15.0        #default 1.0
+      publish_frequency: 15.0       #default 1.0
       global_frame: map
       robot_base_frame: base_link
       use_sim_time: false

--- a/robotino_navigation/config/nav2_params.yaml
+++ b/robotino_navigation/config/nav2_params.yaml
@@ -386,7 +386,7 @@ smoother_server:
 
 behavior_server:
   ros__parameters:
-    cycle_frequency: 20.0
+    cycle_frequency: 15.0
     action_server_result_timeout: 5.0
     behavior_plugins: ["spin", "backup", "drive_on_heading", "assisted_teleop", "wait"]
     spin:

--- a/robotino_navigation/config/nav2_params.yaml
+++ b/robotino_navigation/config/nav2_params.yaml
@@ -432,9 +432,8 @@ velocity_smoother:
     smoothing_frequency: 15.0
     scale_velocities: False
     feedback: "OPEN_LOOP"
-    # TODO: WTF are those values?!?
-    max_velocity: [1.0, 1.0, 1.0]
-    min_velocity: [-1.0, -1.0, -1.0]
+    max_velocity: [1.0, 1.0, 1.25]
+    min_velocity: [-1.0, -1.0, -1.25]
     max_accel: [2.0, 2.0, 3.2]
     max_decel: [-2.0, -2.0, -3.2]
     odom_topic: "/odom_filtered"

--- a/robotino_navigation/config/nav2_params.yaml
+++ b/robotino_navigation/config/nav2_params.yaml
@@ -341,8 +341,8 @@ map_saver:
 
 planner_server:
   ros__parameters:
-    expected_planner_frequency: 20.0
-    use_sim_time: false
+    expected_planner_frequency: 15.0
+    use_sim_time: False
     planner_plugins: ["GridBased"]
     # GridBased:
     #   plugin: "nav2_navfn_planner/NavfnPlanner"

--- a/robotino_navigation/config/nav2_params.yaml
+++ b/robotino_navigation/config/nav2_params.yaml
@@ -85,11 +85,11 @@ bt_navigator:
 
 controller_server:
   ros__parameters:
-    use_sim_time: false
-    controller_frequency: 20.0
-    min_x_velocity_threshold: 0.0001  # default:0.0
-    min_y_velocity_threshold: 0.0001  # default:0.0
-    min_theta_velocity_threshold: 0.0001  # default:0.0
+    use_sim_time: False
+    controller_frequency: 15.0
+    min_x_velocity_threshold: 0.0001 #default:0.0
+    min_y_velocity_threshold: 0.0001 #default:0.0
+    min_theta_velocity_threshold: 0.0001 #default:0.0
     odom_topic: "/odom_filtered"
     failure_tolerance: 0.0 # default: 0.3, The maximum duration in seconds the called controller plugin can fail
     progress_checker_plugins: ["progress_checker"]

--- a/robotino_navigation/config/nav2_params.yaml
+++ b/robotino_navigation/config/nav2_params.yaml
@@ -121,11 +121,11 @@ controller_server:
       batch_size: 2000  # robotino motion model likely needs to be adapted
       vx_std: 0.4
       vy_std: 0.4
-      wz_std: 0.4
+      wz_std: 1.0
       vx_max: 0.7
       vx_min: -0.7
       vy_max: 0.7
-      wz_max: 0.8
+      wz_max: 1.25
       iteration_count: 1
       # TODO: ours was 0.7
       prune_distance: 1.7

--- a/robotino_navigation/config/nav2_params.yaml
+++ b/robotino_navigation/config/nav2_params.yaml
@@ -116,9 +116,9 @@ controller_server:
       plugin: "nav2_mppi_controller::MPPIController"
       # Time_steps times model_dt times vx_max should be < than than halve of
       # The local costmap size, otherwise the robot will never reach full speed
-      time_steps: 80  # model_dt depends on the controller frequency
-      model_dt: 0.05
-      batch_size: 2000  # robotino motion model likely needs to be adapted
+      time_steps: 59  # model_dt depends on the controller frequency
+      model_dt: 0.067
+      batch_size: 2000 # robotino motion model likely needs to be adapted
       vx_std: 0.4
       vy_std: 0.4
       wz_std: 1.0

--- a/robotino_navigation/config/nav2_params.yaml
+++ b/robotino_navigation/config/nav2_params.yaml
@@ -428,9 +428,9 @@ waypoint_follower:
 
 velocity_smoother:
   ros__parameters:
-    use_sim_time: false
-    smoothing_frequency: 20.0
-    scale_velocities: false
+    use_sim_time: False
+    smoothing_frequency: 15.0
+    scale_velocities: False
     feedback: "OPEN_LOOP"
     # TODO: WTF are those values?!?
     max_velocity: [1.0, 1.0, 1.0]

--- a/robotino_sensors/config/ekf.yaml
+++ b/robotino_sensors/config/ekf.yaml
@@ -1,12 +1,11 @@
 ### ekf config file ###
 /**:
   ros__parameters:
-
-    use_sim_time: false
-    # The frequency, in Hz, at which the filter will output a position estimate. Note that the filter will not begin
-    # computation until it receives at least one message from one of the inputs. It will then run continuously at the
-    # frequency specified here, regardless of whether it receives more measurements. Defaults to 30 if unspecified.
-    frequency: 20.0  # (imu and odom topic are being published at 20Hz)
+        use_sim_time: false
+        # The frequency, in Hz, at which the filter will output a position estimate. Note that the filter will not begin
+        # computation until it receives at least one message from one of the inputs. It will then run continuously at the
+        # frequency specified here, regardless of whether it receives more measurements. Defaults to 30 if unspecified.
+        frequency: 15.0 #(imu and odom topic are being published at 20Hz)
 
     # The period, in seconds, after which we consider a sensor to have timed out. In this event, we carry out a predict
     # cycle on the EKF without correcting it. This parameter can be thought of as the minimum frequency with which the

--- a/robotino_sensors/config/ekf.yaml
+++ b/robotino_sensors/config/ekf.yaml
@@ -1,11 +1,12 @@
 ### ekf config file ###
 /**:
   ros__parameters:
-        use_sim_time: false
-        # The frequency, in Hz, at which the filter will output a position estimate. Note that the filter will not begin
-        # computation until it receives at least one message from one of the inputs. It will then run continuously at the
-        # frequency specified here, regardless of whether it receives more measurements. Defaults to 30 if unspecified.
-        frequency: 15.0 #(imu and odom topic are being published at 20Hz)
+
+    use_sim_time: false
+    # The frequency, in Hz, at which the filter will output a position estimate. Note that the filter will not begin
+    # computation until it receives at least one message from one of the inputs. It will then run continuously at the
+    # frequency specified here, regardless of whether it receives more measurements. Defaults to 30 if unspecified.
+    frequency: 15.0 #(imu and odom topic are being published at 20Hz)
 
     # The period, in seconds, after which we consider a sensor to have timed out. In this event, we carry out a predict
     # cycle on the EKF without correcting it. This parameter can be thought of as the minimum frequency with which the


### PR DESCRIPTION
- lowered the rates of controller components to 15 Hz which is the rate of the slowest component involved, namely the lidars
- lowered time steps and model_dt to get the same horizon as before 
- updated wz max and std according to measurements and trials
- increased smoother_server min_max_z_velocity