### PR TITLE
Hedemann soomro inflation

### DIFF
--- a/robotino_navigation/config/nav2_params.yaml
+++ b/robotino_navigation/config/nav2_params.yaml
@@ -234,7 +234,7 @@ local_costmap:
       plugins: ["obstacle_layer", "inflation_layer", "denoise_layer"] # "voxel_layer"
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
-        enable: true
+        enabled: true
         cost_scaling_factor: 5.0
         inflation_radius: 0.40
       obstacle_layer:

--- a/robotino_navigation/config/nav2_params.yaml
+++ b/robotino_navigation/config/nav2_params.yaml
@@ -188,7 +188,7 @@ controller_server:
       #   collision_cost: 10000.0
       #   collision_margin_distance: 0.1
       #   near_goal_distance: 0.1
-      #   inflation_radius: 1.0 # (only in Humble)
+      #   inflation_radius: 0.4 # (only in Humble)
       #   cost_scaling_factor: 5.0 # (only in Humble)
       PathAlignCritic:
         enabled: true

--- a/robotino_navigation/config/nav2_params.yaml
+++ b/robotino_navigation/config/nav2_params.yaml
@@ -185,8 +185,8 @@ controller_server:
       #   repulsion_weight: 1.5
       #   critical_weight: 20.0
       #   consider_footprint: true # default: false, incerase the computation cost, uses robot footprint information
-      #   collision_cost: 10000.0
-      #   collision_margin_distance: 0.1
+      #   collision_cost: 1000.0
+      #   collision_margin_distance: 0.05
       #   near_goal_distance: 0.1
       #   inflation_radius: 0.4 # (only in Humble)
       #   cost_scaling_factor: 5.0 # (only in Humble)
@@ -235,8 +235,8 @@ local_costmap:
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
         enabled: true
-        cost_scaling_factor: 5.0
-        inflation_radius: 0.40
+        cost_scaling_factor: 1.0
+        inflation_radius: 0.4
       obstacle_layer:
         plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: true
@@ -316,11 +316,11 @@ global_costmap:
           obstacle_min_range: 0.0
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
-        cost_scaling_factor: 5.0
-        inflation_radius: 0.6
-        inflate_unknown: false
-        inflate_around_unknown: false
-      always_send_full_costmap: true
+        cost_scaling_factor: 1.0
+        inflation_radius: 0.4
+        inflate_unknown: False
+        inflate_around_unknown: False
+      always_send_full_costmap: True
 
 map_server:
   ros__parameters:

--- a/robotino_navigation/map/map_go.yaml
+++ b/robotino_navigation/map/map_go.yaml
@@ -1,0 +1,7 @@
+image: GO_MAP.pgm
+mode: trinary
+resolution: 0.01
+origin: [-12.0, -5.0, 0]
+negate: 0
+occupied_thresh: 0.65
+free_thresh: 0.25

--- a/robotino_navigation/map/map_go.yaml
+++ b/robotino_navigation/map/map_go.yaml
@@ -1,7 +1,0 @@
-image: GO_MAP.pgm
-mode: trinary
-resolution: 0.01
-origin: [-12.0, -5.0, 0]
-negate: 0
-occupied_thresh: 0.65
-free_thresh: 0.25


### PR DESCRIPTION
- builds on changes from hedemann_soomro/tuning_hz_parameters

- inflation layer 
   - parameter tuning: cost_scaling_factor, inflation_radius (9b382895c0ed36885884b8f16f34830621cfacf3)
   - fixed typo enable[d]

- obstacle critic (9b382895c0ed36885884b8f16f34830621cfacf3)
   - aligned inflation_radius to local cost map's one
   - changed collision_cost, collision_margin_distance, cost_scaling_factor

- added "GO_MAP"