### PR TITLE
Fix: fixed lidar and irscan param for local costmap

### DIFF
--- a/robotino_navigation/config/nav2_params.yaml
+++ b/robotino_navigation/config/nav2_params.yaml
@@ -25,7 +25,7 @@ amcl:
     save_pose_rate: 0.5
     tf_broadcast: true
     transform_tolerance: 1.0
-    scan_topic: /fawkes_scans/Laser_urg_filtered_360
+    scan_topic: /scan
 
     # values from fawkes AMCL
     # alpha values
@@ -305,7 +305,7 @@ local_costmap:
         footprint_clearing_enabled: True
         observation_sources: scan_lidar scan_ir
         scan_lidar:
-          topic: /fawkes_scans/Laser_urg_filtered_360
+          topic: /scan
           max_obstacle_height: 2.0
           clearing: true
           marking: true
@@ -377,7 +377,7 @@ global_costmap:
         footprint_clearing_enabled: true
         observation_sources: scan
         scan:
-          topic: /fawkes_scans/Laser_urg_filtered_360
+          topic: /scan
           max_obstacle_height: 2.0
           clearing: true
           marking: true
@@ -565,7 +565,7 @@ collision_monitor:
     scan:
       source_timeout: 0.2
       type: "scan"
-      topic: "/fawkes_scans/Laser_urg_filtered_360"
+      topic: "/scan"
       min_height: 0.15
       max_height: 2.0
       enabled: true

--- a/robotino_navigation/config/nav2_params.yaml
+++ b/robotino_navigation/config/nav2_params.yaml
@@ -306,6 +306,7 @@ local_costmap:
         observation_sources: scan_lidar scan_ir
         scan_lidar:
           topic: /scan
+          sensor_frame: laser_link
           max_obstacle_height: 2.0
           clearing: true
           marking: true
@@ -316,6 +317,7 @@ local_costmap:
           obstacle_min_range: 0.0
         scan_ir:
           topic: /irsensor_scan
+          sensor_frame: irscan_link
           max_obstacle_height: 2.0
           clearing: True
           marking: True

--- a/robotino_navigation/config/robotinobase1_nav2_params.yaml
+++ b/robotino_navigation/config/robotinobase1_nav2_params.yaml
@@ -25,8 +25,10 @@ local_costmap:
       global_frame: robotinobase1/odom
       robot_base_frame: robotinobase1/base_link
       obstacle_layer:
-        scan:
+        scan_lidar:
           topic: /robotinobase1/scan
+        scan_ir:
+          topic: /robotinobase1/irsensor_scan
 
 global_costmap:
   global_costmap:

--- a/robotino_navigation/config/robotinobase1_nav2_params.yaml
+++ b/robotino_navigation/config/robotinobase1_nav2_params.yaml
@@ -27,8 +27,10 @@ local_costmap:
       obstacle_layer:
         scan_lidar:
           topic: /robotinobase1/scan
+          sensor_frame: robotinobase1/laser_link
         scan_ir:
           topic: /robotinobase1/irsensor_scan
+          sensor_frame: robotinobase1/irscan_link
 
 global_costmap:
   global_costmap:
@@ -37,6 +39,7 @@ global_costmap:
       obstacle_layer:
         scan:
           topic: /robotinobase1/scan
+          sensor_frame: robotinobase1/laser_link
 
 map_server:
   ros__parameters:

--- a/robotino_navigation/config/robotinobase2_nav2_params.yaml
+++ b/robotino_navigation/config/robotinobase2_nav2_params.yaml
@@ -25,8 +25,10 @@ local_costmap:
       global_frame: robotinobase2/odom
       robot_base_frame: robotinobase2/base_link
       obstacle_layer:
-        scan:
+        scan_lidar:
           topic: /robotinobase2/scan
+        scan_ir:
+          topic: /robotinobase2/irsensor_scan
 
 global_costmap:
   global_costmap:

--- a/robotino_navigation/config/robotinobase2_nav2_params.yaml
+++ b/robotino_navigation/config/robotinobase2_nav2_params.yaml
@@ -27,8 +27,10 @@ local_costmap:
       obstacle_layer:
         scan_lidar:
           topic: /robotinobase2/scan
+          sensor_frame: robotinobase2/laser_link
         scan_ir:
           topic: /robotinobase2/irsensor_scan
+          sensor_frame: robotinobase2/irscan_link
 
 global_costmap:
   global_costmap:
@@ -37,6 +39,7 @@ global_costmap:
       obstacle_layer:
         scan:
           topic: /robotinobase2/scan
+          sensor_frame: robotinobase2/laser_link
 
 map_server:
   ros__parameters:

--- a/robotino_navigation/config/robotinobase3_nav2_params.yaml
+++ b/robotino_navigation/config/robotinobase3_nav2_params.yaml
@@ -27,8 +27,10 @@ local_costmap:
       obstacle_layer:
         scan_lidar:
           topic: /robotinobase3/scan
+          sensor_frame: robotinobase3/laser_link
         scan_ir:
           topic: /robotinobase3/irsensor_scan
+          sensor_frame: robotinobase3/irscan_link
 
 global_costmap:
   global_costmap:
@@ -37,6 +39,7 @@ global_costmap:
       obstacle_layer:
         scan:
           topic: /robotinobase3/scan
+          sensor_frame: robotinobase3/laser_link
 
 map_server:
   ros__parameters:

--- a/robotino_navigation/config/robotinobase3_nav2_params.yaml
+++ b/robotino_navigation/config/robotinobase3_nav2_params.yaml
@@ -25,8 +25,10 @@ local_costmap:
       global_frame: robotinobase3/odom
       robot_base_frame: robotinobase3/base_link
       obstacle_layer:
-        scan:
+        scan_lidar:
           topic: /robotinobase3/scan
+        scan_ir:
+          topic: /robotinobase3/irsensor_scan
 
 global_costmap:
   global_costmap:

--- a/robotino_navigation/config/robotinobase4_nav2_params.yaml
+++ b/robotino_navigation/config/robotinobase4_nav2_params.yaml
@@ -22,8 +22,10 @@ local_costmap:
       obstacle_layer:
         scan_lidar:
           topic: /robotinobase4/scan
+          sensor_frame: robotinobase4/laser_link
         scan_ir:
           topic: /robotinobase4/irsensor_scan
+          sensor_frame: robotinobase4/irscan_link
 
 global_costmap:
   global_costmap:
@@ -32,6 +34,7 @@ global_costmap:
       obstacle_layer:
         scan:
           topic: /robotinobase4/scan
+          sensor_frame: robotinobase4/laser_link
 
 map_server:
   ros__parameters:

--- a/robotino_navigation/config/robotinobase4_nav2_params.yaml
+++ b/robotino_navigation/config/robotinobase4_nav2_params.yaml
@@ -20,8 +20,10 @@ local_costmap:
       global_frame: robotinobase4/odom
       robot_base_frame: robotinobase4/base_link
       obstacle_layer:
-        scan:
+        scan_lidar:
           topic: /robotinobase4/scan
+        scan_ir:
+          topic: /robotinobase4/irsensor_scan
 
 global_costmap:
   global_costmap:


### PR DESCRIPTION
Updated the local cost map obstacle layer parameters. The scan_lidar and scan_ir were not set properly in the host-specific nav2 parameter file. 